### PR TITLE
🎨 Palette: Update chart color for WCAG AA accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+## 2025-03-05 - Chart Color Contrast
+
+**Learning:** When using colors to distinguish data points in charts, as well as for associated text labels, it's crucial to ensure sufficient color contrast against the background to meet WCAG AA guidelines (1.4.11 for Non-text Contrast, requiring 3.0:1, and 1.4.3 for Contrast (Minimum), requiring 4.5:1 for regular text). The original orange `#FF7F0E` had a contrast ratio of 2.53:1 against white, which fails both standards.
+**Action:** Always verify the contrast ratio of data visualization colors, particularly when the same color is used for text labels. Darken the color to ensure it has at least a 4.5:1 ratio if used for text, or 3.0:1 if only used for graphical objects. In this case, darkening to `#CC4C02` achieved a 4.56:1 contrast ratio while keeping the semantic "orange" meaning.

--- a/src/hydrograph_seatek_analysis/visualization/chart_generator.py
+++ b/src/hydrograph_seatek_analysis/visualization/chart_generator.py
@@ -113,8 +113,8 @@ class ChartGenerator:
             # Configure primary axis
             ax1.set_xlabel('Time (Minutes)', fontsize=12, labelpad=10)
             ax1.set_ylabel('Seatek Sensor Reading (NAVD88)',
-                          color='#FF7F0E', fontsize=12)
-            ax1.tick_params(axis='y', labelcolor='#FF7F0E')
+                          color='#CC4C02', fontsize=12)
+            ax1.tick_params(axis='y', labelcolor='#CC4C02')
             ax1.grid(True, alpha=0.2, linestyle=':')
 
             # Add hydrograph if available
@@ -154,7 +154,7 @@ class ChartGenerator:
             ax1.scatter(
                 sensor_data['Time (Minutes)'],
                 sensor_data[sensor],
-                color='#FF7F0E',
+                color='#CC4C02',
                 alpha=0.7,
                 s=45,
                 label=f'Sensor {sensor.split("_")[1] if "_" in sensor else sensor} (NAVD88)'

--- a/src/hydrograph_seatek_analysis/visualization/chart_generator.py
+++ b/src/hydrograph_seatek_analysis/visualization/chart_generator.py
@@ -113,8 +113,8 @@ class ChartGenerator:
             # Configure primary axis
             ax1.set_xlabel('Time (Minutes)', fontsize=12, labelpad=10)
             ax1.set_ylabel('Seatek Sensor Reading (NAVD88)',
-                          color='#CC4C02', fontsize=12)
-            ax1.tick_params(axis='y', labelcolor='#CC4C02')
+                          color=SEATEK_COLOR, fontsize=12)
+            ax1.tick_params(axis='y', labelcolor=SEATEK_COLOR)
             ax1.grid(True, alpha=0.2, linestyle=':')
 
             # Add hydrograph if available


### PR DESCRIPTION
💡 **What**: Updated the primary color used for the Seatek sensor data visualization from a light orange (`#FF7F0E`) to a darker shade of orange (`#CC4C02`). Also created a `.jules/palette.md` file to track UX/accessibility learnings.

🎯 **Why**: The previous light orange color had a contrast ratio of `2.53:1` against the white background. This fails WCAG AA guidelines (1.4.11 requires 3.0:1 for graphical objects, and 1.4.3 requires 4.5:1 for standard text labels). By darkening the color to `#CC4C02`, the contrast ratio is improved to `4.56:1`, making the chart and its axis labels readable and fully accessible while maintaining the original semantic design intent.

♿ **Accessibility**: Resolves WCAG 1.4.3 (Contrast Minimum) and WCAG 1.4.11 (Non-text Contrast) failures in the generated charts.

---
*PR created automatically by Jules for task [18099104400718495227](https://jules.google.com/task/18099104400718495227) started by @abhimehro*