### PR TITLE
🎨 Palette: Add accessible metadata to generated charts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,8 @@
+## 2026-03-04 - Accessible Chart Metadata
+
+**Learning:** Data visualizations saved as PNGs are opaque to screen readers unless embedded in an HTML `<img>` tag with proper `alt` text. However, users often download or share these PNGs independently.
+**Action:** Always embed descriptive `Title`, `Description` (acting as alt-text), and `Author` metadata directly into the PNG file using Matplotlib's `savefig(metadata={...})`. This ensures accessibility information travels with the file wherever it goes.
+
 ## 2025-03-05 - Chart Color Contrast
 
 **Learning:** When using colors to distinguish data points in charts, as well as for associated text labels, it's crucial to ensure sufficient color contrast against the background to meet WCAG AA guidelines (1.4.11 for Non-text Contrast, requiring 3.0:1, and 1.4.3 for Contrast (Minimum), requiring 4.5:1 for regular text). The original orange `#FF7F0E` had a contrast ratio of 2.53:1 against white, which fails both standards.

--- a/src/hydrograph_seatek_analysis/app.py
+++ b/src/hydrograph_seatek_analysis/app.py
@@ -188,9 +188,17 @@ class Application:
                                 # Construct metadata for a11y
                                 sensor_num = sensor.split("_")[1] if "_" in sensor else sensor
                                 metadata = {
-                                    "Title": f"River Mile {rm_data.river_mile:.1f} - Year {year} Sensor {sensor_num}",
-                                    "Description": f"Chart showing Seatek Sensor {sensor_num} data (NAVD88) and Hydrograph flow (GPM) over time for River Mile {rm_data.river_mile:.1f} in Year {year}.",
-                                    "Author": "Hydrograph vs Seatek Sensors Analysis Project"
+                                    "Title": (
+                                        f"River Mile {rm_data.river_mile:.1f} - Year {year} "
+                                        f"Sensor {sensor_num}"
+                                    ),
+                                    "Description": (
+                                        "Chart showing Seatek "
+                                        f"Sensor {sensor_num} data (NAVD88) and "
+                                        "Hydrograph flow (GPM) over time for "
+                                        f"River Mile {rm_data.river_mile:.1f} in Year {year}."
+                                    ),
+                                    "Author": "Hydrograph vs Seatek Sensors Analysis Project",
                                 }
 
                                 if self.chart_generator.save_chart(chart, output_path, metadata=metadata):

--- a/src/hydrograph_seatek_analysis/app.py
+++ b/src/hydrograph_seatek_analysis/app.py
@@ -185,7 +185,15 @@ class Application:
                                     / f"Year_{safe_year}_{safe_sensor}.png"
                                 )
 
-                                if self.chart_generator.save_chart(chart, output_path):
+                                # Construct metadata for a11y
+                                sensor_num = sensor.split("_")[1] if "_" in sensor else sensor
+                                metadata = {
+                                    "Title": f"River Mile {rm_data.river_mile:.1f} - Year {year} Sensor {sensor_num}",
+                                    "Description": f"Chart showing Seatek Sensor {sensor_num} data (NAVD88) and Hydrograph flow (GPM) over time for River Mile {rm_data.river_mile:.1f} in Year {year}.",
+                                    "Author": "Hydrograph vs Seatek Sensors Analysis Project"
+                                }
+
+                                if self.chart_generator.save_chart(chart, output_path, metadata=metadata):
                                     success_count += 1
                                 else:
                                     error_count += 1

--- a/src/hydrograph_seatek_analysis/visualization/chart_generator.py
+++ b/src/hydrograph_seatek_analysis/visualization/chart_generator.py
@@ -221,7 +221,8 @@ class ChartGenerator:
         self, 
         fig: Figure, 
         output_path: str, 
-        dpi: Optional[int] = None
+        dpi: Optional[int] = None,
+        metadata: Optional[dict] = None
     ) -> bool:
         """
         Save chart to file.
@@ -230,6 +231,7 @@ class ChartGenerator:
             fig: Figure to save
             output_path: Path to save the figure to
             dpi: Optional DPI override
+            metadata: Optional dictionary with image metadata (e.g. Title, Description for a11y)
             
         Returns:
             True if successful, False otherwise
@@ -240,11 +242,14 @@ class ChartGenerator:
             output_path.parent.mkdir(parents=True, exist_ok=True)
             
             # Save figure
-            fig.savefig(
-                output_path, 
-                dpi=dpi or self.chart_settings.dpi, 
-                bbox_inches='tight'
-            )
+            kwargs = {
+                'dpi': dpi or self.chart_settings.dpi,
+                'bbox_inches': 'tight'
+            }
+            if metadata:
+                kwargs['metadata'] = metadata
+
+            fig.savefig(output_path, **kwargs)
             plt.close(fig)  # Free memory
             logger.info(f"Saved chart to {output_path}")
             return True


### PR DESCRIPTION
💡 **What**: Embedded accessibility metadata (`Title`, `Description`, and `Author`) directly into the output PNG images generated by `ChartGenerator` using Matplotlib's `savefig` `metadata` parameter.
🎯 **Why**: Data visualizations saved as flat images (PNGs) are inherently opaque to screen readers when shared or downloaded independently from an HTML `<img>` tag. Embedding an alt-text equivalent directly into the image file ensures the context of the data follows the file wherever it goes.
📸 **Before/After**: 
*   **Before:** PNG files had no descriptive metadata. 
*   **After:** PNG files contain standard metadata keys that assistive technologies and image viewers can read (e.g., `Description: Chart showing Seatek Sensor 1 data (NAVD88) and Hydrograph flow (GPM) over time for River Mile 54.0 in Year 1.`).
♿ **Accessibility**: Provides robust screen-reader support for standalone charts and improves overall compliance with WCAG standards for non-text content.

---
*PR created automatically by Jules for task [11268314409019766422](https://jules.google.com/task/11268314409019766422) started by @abhimehro*