### PR TITLE
🎨 Palette: Improve chart marker contrast for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,8 @@
+## 2025-03-05 - Avoid Alpha for Data Markers
+
+**Learning:** Data points in scatter plots with `alpha` (opacity) below 1.0 on a white background visually lighten the marker color. A WCAG-compliant color like `#A63600` (which has a 6.67:1 contrast ratio) may drop below the required 3.0:1 non-text contrast ratio if rendered at `alpha=0.7`.
+**Action:** When plotting accessible charts, avoid using `alpha` to handle overlapping data points. Instead, use `alpha=1.0` combined with subtle marker edge outlines (e.g., `edgecolors='white', linewidth=0.5`) or distinct markers to distinguish overlapping data while maintaining the true contrast of the base color.
+
 ## 2026-03-04 - Accessible Chart Metadata
 
 **Learning:** Data visualizations saved as PNGs are opaque to screen readers unless embedded in an HTML `<img>` tag with proper `alt` text. However, users often download or share these PNGs independently.

--- a/src/hydrograph_seatek_analysis/visualization/chart_generator.py
+++ b/src/hydrograph_seatek_analysis/visualization/chart_generator.py
@@ -191,8 +191,8 @@ class ChartGenerator:
                     alpha=1.0,
                     s=70,
                     marker='s',
-                    edgecolors='white',
-                    linewidth=0.5,
+                    edgecolors=MARKER_EDGE_COLOR,
+                    linewidth=MARKER_EDGE_LINEWIDTH,
                     label='Hydrograph (GPM)'
                 )
                 ax2.set_ylabel('Hydrograph (GPM)', color=HYDRO_COLOR, fontsize=12)

--- a/src/hydrograph_seatek_analysis/visualization/chart_generator.py
+++ b/src/hydrograph_seatek_analysis/visualization/chart_generator.py
@@ -165,8 +165,8 @@ class ChartGenerator:
                 color=SEATEK_COLOR,
                 alpha=1.0,
                 s=45,
-                edgecolors='white',
-                linewidth=0.5,
+                edgecolors=MARKER_EDGE_COLOR,
+                linewidth=MARKER_EDGE_LINEWIDTH,
                 label=f'Sensor {sensor.split("_")[1] if "_" in sensor else sensor} (NAVD88)'
             )
 

--- a/src/hydrograph_seatek_analysis/visualization/chart_generator.py
+++ b/src/hydrograph_seatek_analysis/visualization/chart_generator.py
@@ -163,8 +163,10 @@ class ChartGenerator:
                 sensor_data['Time (Minutes)'],
                 sensor_data[sensor],
                 color=SEATEK_COLOR,
-                alpha=0.7,
+                alpha=1.0,
                 s=45,
+                edgecolors='white',
+                linewidth=0.5,
                 label=f'Sensor {sensor.split("_")[1] if "_" in sensor else sensor} (NAVD88)'
             )
 
@@ -186,9 +188,11 @@ class ChartGenerator:
                     hydro_data['Time (Minutes)'],
                     hydro_data['Hydrograph (Lagged)'],
                     color=HYDRO_COLOR,
-                    alpha=0.7,
+                    alpha=1.0,
                     s=70,
                     marker='s',
+                    edgecolors='white',
+                    linewidth=0.5,
                     label='Hydrograph (GPM)'
                 )
                 ax2.set_ylabel('Hydrograph (GPM)', color=HYDRO_COLOR, fontsize=12)


### PR DESCRIPTION
💡 What: Replaced `alpha=0.7` with `alpha=1.0` and added `edgecolors='white', linewidth=0.5` to scatter plot markers in `ChartGenerator`.
🎯 Why: While the base colors chosen (`#A63600` and `#0E5A8A`) meet the WCAG contrast requirements against a white background, applying a 0.7 opacity visually lightens them and reduces the contrast ratio, potentially falling below the 3.0:1 requirement for non-text contrast. 
📸 Before/After: Data points are now fully opaque, but still visually distinguishable when overlapping due to the subtle white edge outlines.
♿ Accessibility: Ensures that data visualizations consistently meet WCAG 2.1 Level AA color contrast guidelines (1.4.11 Non-text Contrast) for users with visual impairments.

---
*PR created automatically by Jules for task [2718007245983006557](https://jules.google.com/task/2718007245983006557) started by @abhimehro*