### PR TITLE
🎨 Palette: [UX improvement] Format axes with commas and decouple legends

### DIFF
--- a/utils/chart_generator.py
+++ b/utils/chart_generator.py
@@ -4,6 +4,7 @@ import logging
 from typing import Optional
 
 import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
 import pandas as pd
 import seaborn as sns
 from matplotlib.figure import Figure
@@ -72,16 +73,45 @@ class ChartGenerator:
             ax1.grid(True, alpha=0.2, linestyle=':')
 
             # Add hydrograph if available
+            ax2 = None
             if 'Hydrograph (Lagged)' in data.columns:
-                self._add_hydrograph(ax1, data)
+                ax2 = self._add_hydrograph(ax1, data)
+
+            # Collect legend handles and labels
+            lines, labels = ax1.get_legend_handles_labels()
+            if ax2 is not None and hasattr(ax2, 'get_legend_handles_labels'):
+                lines2, labels2 = ax2.get_legend_handles_labels()
+                lines.extend(lines2)
+                labels.extend(labels2)
+
+            if lines:
+                ax1.legend(
+                    lines,
+                    labels,
+                    loc='upper center',
+                    bbox_to_anchor=(0.5, -0.15),
+                    framealpha=1.0,
+                    edgecolor='#333333',
+                    ncol=2,
+                    fontsize=11
+                )
+
+            # Apply formatting safely based on data types
+            # X-axis time formatting
+            if 'Time (Minutes)' in data.columns and pd.api.types.is_numeric_dtype(data['Time (Minutes)']):
+                ax1.xaxis.set_major_formatter(ticker.StrMethodFormatter("{x:,.0f}"))
+
+            # Y-axis sensor formatting
+            if sensor in data.columns and pd.api.types.is_numeric_dtype(data[sensor]):
+                ax1.yaxis.set_major_formatter(ticker.StrMethodFormatter("{x:.2f}"))
 
             # Set title and format plot
-            plt.title(
-                f'River Mile {river_mile:.1f} - Year {year}\n'
-                f'Seatek Sensor {sensor.split("_")[1]} Data with Hydrograph',
-                pad=20,
-                fontsize=14
-            )
+            sensor_num = sensor.split("_")[1] if "_" in sensor else sensor
+            title_text = f"River Mile {river_mile:.1f} - Year {year}\nSeatek Sensor {sensor_num} Data"
+            if ax2 is not None:
+                title_text += " with Hydrograph"
+
+            plt.title(title_text, pad=20, fontsize=14)
 
             plt.tight_layout()
             return fig
@@ -92,7 +122,7 @@ class ChartGenerator:
             return None
 
     @staticmethod
-    def _add_hydrograph(ax1: plt.Axes, data: pd.DataFrame) -> None:
+    def _add_hydrograph(ax1: plt.Axes, data: pd.DataFrame) -> Optional[plt.Axes]:
         """Add hydrograph data to the plot."""
         try:
             ax2 = ax1.twinx()
@@ -113,18 +143,16 @@ class ChartGenerator:
                 ax2.set_ylabel('Hydrograph (GPM)', color='#0E5A8A', fontsize=12)
                 ax2.tick_params(axis='y', labelcolor='#0E5A8A')
 
-                # Add legend
-                lines1, labels1 = ax1.get_legend_handles_labels()
-                lines2, labels2 = ax2.get_legend_handles_labels()
-                ax1.legend(
-                    lines1 + lines2,
-                    labels1 + labels2,
-                    loc='upper center',
-                    bbox_to_anchor=(0.5, -0.15),
-                    framealpha=1.0,
-                    edgecolor='#333333',
-                    ncol=2,
-                    fontsize=11
-                )
+                if pd.api.types.is_numeric_dtype(data['Hydrograph (Lagged)']):
+                    hydro_values = hydro_data['Hydrograph (Lagged)']
+                    max_frac_deviation = (hydro_values - hydro_values.round()).abs().max()
+                    if pd.notna(max_frac_deviation) and max_frac_deviation < 1e-6:
+                        hydro_fmt = "{x:,.0f}"
+                    else:
+                        hydro_fmt = "{x:,.2f}"
+                    ax2.yaxis.set_major_formatter(ticker.StrMethodFormatter(hydro_fmt))
+
+            return ax2
         except Exception as e:
             logger.error(f"Error adding hydrograph: {str(e)}")
+            return None

--- a/utils/visualizer.py
+++ b/utils/visualizer.py
@@ -1,6 +1,7 @@
 """Visualization utilities for Seatek sensor data."""
 
 import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
 import seaborn as sns
 import pandas as pd
 import logging
@@ -65,7 +66,7 @@ class SeatekVisualizer:
             if 'Hydrograph (Lagged)' in data.columns:
                 self._add_hydrograph_data(axes[0], axes[1], data)
 
-            self._format_plot(fig, axes[0], river_mile, year, sensor)
+            self._format_plot(fig, axes[0], river_mile, year, sensor, data)
 
             if output_path:
                 self._save_plot(fig, output_path)
@@ -138,7 +139,8 @@ class SeatekVisualizer:
             ax: plt.Axes,
             river_mile: float,
             year: int,
-            sensor: str
+            sensor: str,
+            data: pd.DataFrame = None
     ) -> None:
         """Format plot with titles, legends, and styling."""
         plt.title(
@@ -174,6 +176,28 @@ class SeatekVisualizer:
                 ncol=2,
                 fontsize=11
             )
+
+        # Apply formatting safely based on data types
+        if data is not None:
+            # X-axis time formatting
+            if 'Time (Minutes)' in data.columns and pd.api.types.is_numeric_dtype(data['Time (Minutes)']):
+                ax.xaxis.set_major_formatter(ticker.StrMethodFormatter("{x:,.0f}"))
+
+            # Y-axis sensor formatting
+            if sensor in data.columns and pd.api.types.is_numeric_dtype(data[sensor]):
+                ax.yaxis.set_major_formatter(ticker.StrMethodFormatter("{x:,.2f}"))
+
+            # Secondary Y-axis hydrograph formatting
+            if 'Hydrograph (Lagged)' in data.columns and pd.api.types.is_numeric_dtype(data['Hydrograph (Lagged)']):
+                if len(fig.axes) > 1:
+                    ax2 = fig.axes[1]
+                    if hasattr(ax2, 'yaxis'):
+                        hydro_vals = data['Hydrograph (Lagged)'].dropna()
+                        max_frac = (hydro_vals - hydro_vals.round()).abs().max()
+                        if pd.notna(max_frac) and max_frac < 1e-6:
+                            ax2.yaxis.set_major_formatter(ticker.StrMethodFormatter("{x:,.0f}"))
+                        else:
+                            ax2.yaxis.set_major_formatter(ticker.StrMethodFormatter("{x:,.2f}"))
 
         plt.tight_layout()
 


### PR DESCRIPTION
💡 What:
Replaced the default raw formatting on Matplotlib axes with comma separation for large numeric values (e.g. 50,000 instead of 50000) on the X-axis (`Time (Minutes)`). Also ensured the primary Y-axis consistently displays two decimal places. Finally, decoupled the legend generation in the legacy `chart_generator.py` to ensure it always renders, even if the secondary hydrograph dataset is missing.

🎯 Why:
Large raw numbers on axes significantly reduce quick readability, increasing the cognitive load for users parsing hydrograph data spanning thousands of minutes. Similarly, if a dataset only contained the primary axis, the legend would silently fail to render in the older code, making the chart harder to understand at a glance. Adding safety checks (`is_numeric_dtype`) ensures that if the axis data type ever changes to datetime, the formatting won't throw an error or overwrite the default datetime string formatting.

📸 Before/After:
Before: `50000` (x-axis), `100.2` (y-axis), no legend if hydrograph missing.
After: `50,000` (x-axis), `100.20` (y-axis), legend always renders.

♿ Accessibility:
Ensures legends are consistently presented to explain data contexts. The use of commas improves cognitive accessibility for reading large sequential datasets.

---
*PR created automatically by Jules for task [1849801087447469411](https://jules.google.com/task/1849801087447469411) started by @abhimehro*