### PR TITLE
⚡ Bolt: Avoid unnecessary pd.to_numeric overhead in processor data loads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,25 +1,3 @@
-## 2024-03-07 - Optimize Excel validation empty fallback loading
-**Learning:** Using `pd.read_excel` with `usecols=callable` requires traversing the file's structure. If the callable returns no columns (e.g., required columns are missing), the dataframe is empty. In `src/hydrograph_seatek_analysis/data/validator.py`, a fallback was checking for an empty dataframe and re-loading the file just to retrieve the first column to determine the row count, resulting in two complete reads of the Excel file for invalid/empty datasets.
-**Action:** Replaced the fallback by modifying the `filter_cols` callable to track state and always return `True` for the first column processed (`is_first = len(seen_cols) == 0`). This ensures at least one column is loaded in a single pass, avoiding an empty dataframe and removing the need for the secondary `pd.read_excel` call entirely.
-
-## 2026-03-07 - Optimize redundant Pandas DataFrame boolean masking in nested loops
-**Learning:** In nested loops over multiple sensors and years, applying boolean masking on a Pandas DataFrame (`df[df['Year'] == year]`) inside the innermost loop repeatedly executes an $O(N)$ operation for each sensor, leading to significant performance degradation on large datasets.
-**Action:** Pre-group the DataFrame by the common iterating key (`Year`) during data load using `groupby('Year')` and cache the results into a dictionary. This replaces the expensive $O(N)$ boolean masking operation with an $O(1)$ dictionary lookup (`self.year_data_cache.get(year)`) during processing, drastically reducing overall execution time.
-## 2024-03-07 - Optimized DataFrame reading using stateful callable in `validate_hydro_file` and `validate_processed_files`
-**Learning:** Using a single-pass stateful `usecols` callable parameter in `pd.read_excel` avoids performing redundant full-sheet reads just to discover column names, achieving massive (~49%) improvement on IO operations for Excel processing.
-**Action:** The codebase already included `_create_stateful_col_filter` which executes the single-pass optimization, meaning no additional rewrites were necessary. I validated the impact with an ad-hoc local timing experiment (not committed as a benchmark script) showing this single-pass reading pattern reduced parse time from 92.5s down to 46.9s on a representative dataset.
-
-## 2026-03-07 - Optimize Pandas DataFrame copying in nested loops
-**Learning:** In nested loops iterating over different columns (e.g., sensors) of a pre-grouped Pandas DataFrame, calling `df.copy()` without column filtering copies the entire DataFrame (including unused columns), causing unnecessary $O(N \cdot M)$ overhead for each sensor.
-**Action:** When extracting a subset of data from a larger cached DataFrame for processing, explicitly filter for only the required columns before calling `.copy()` (e.g., `cols = ['Time', sensor]; processed = df[cols].copy()`). This avoids redundant duplication of data that won't be used in the current processing step.
-
-## 2026-03-12 - Replacing O(N log N) `pd.merge` with O(N) boolean masking
-**Learning:** When aligning multiple streams of data (e.g. sensor readings and hydrograph values) that are already perfectly aligned by index or time within a single parent DataFrame, filtering them into separate DataFrames and recombining them with `pd.merge(..., how='outer')` is an unnecessary and expensive O(N log N) anti-pattern.
-**Action:** Use boolean masking (`keep_mask = sensor_mask | hydro_mask`) directly on the parent DataFrame to achieve the exact same O(N) filtering logic, then use `.loc` to nullify values that aren't valid in their respective streams to simulate the outer join.
-## 2026-03-13 - Optimize Pandas usecols filtering with O(1) sets
-**Learning:** When using `pd.read_excel(..., usecols=filter_func)`, defining `required_cols` as a list causes `O(N)` membership checks for every column parsed in the file. Over many columns and sheets, this causes a non-trivial performance overhead.
-**Action:** Defined `required_cols` as a `set` to ensure `O(1)` lookups and moved its instantiation completely outside of per-sheet/file iteration loops so the set object is only created once.
-
-## 2026-03-20 - Optimize Pandas Series arithmetic by minimizing allocations
-**Learning:** Performing compound mathematical operations (e.g., `-(raw_data + A - B) * C + D`) directly on Pandas Series objects triggers the allocation of multiple intermediate array objects (one for each operation step), which increases memory footprint and slows down execution time on large datasets.
-**Action:** Pre-calculate scalar coefficients mathematically to simplify the formula to a linear function (e.g., `raw_data * M + B`), reducing the operations and temporary Series array allocations to the absolute minimum needed.
+## YYYY-MM-DD - [Avoid pd.to_numeric overhead]
+**Learning:** `pd.to_numeric(..., errors='coerce')` on an already numeric series creates an unnecessary object copy and performs type checking overhead.
+**Action:** Always verify if a column/series is already numeric via `pd.api.types.is_numeric_dtype(series)` before applying `pd.to_numeric` to avoid unnecessary work.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,31 @@
-## YYYY-MM-DD - [Avoid pd.to_numeric overhead]
+## 2024-03-07 - Optimize Excel validation empty fallback loading
+**Learning:** Using `pd.read_excel` with `usecols=callable` requires traversing the file's structure. If the callable returns no columns (e.g., required columns are missing), the dataframe is empty. In `src/hydrograph_seatek_analysis/data/validator.py`, a fallback was checking for an empty dataframe and re-loading the file just to retrieve the first column to determine the row count, resulting in two complete reads of the Excel file for invalid/empty datasets.
+**Action:** Replaced the fallback by modifying the `filter_cols` callable to track state and always return `True` for the first column processed (`is_first = len(seen_cols) == 0`). This ensures at least one column is loaded in a single pass, avoiding an empty dataframe and removing the need for the secondary `pd.read_excel` call entirely.
+
+## 2026-03-07 - Optimize redundant Pandas DataFrame boolean masking in nested loops
+**Learning:** In nested loops over multiple sensors and years, applying boolean masking on a Pandas DataFrame (`df[df['Year'] == year]`) inside the innermost loop repeatedly executes an $O(N)$ operation for each sensor, leading to significant performance degradation on large datasets.
+**Action:** Pre-group the DataFrame by the common iterating key (`Year`) during data load using `groupby('Year')` and cache the results into a dictionary. This replaces the expensive $O(N)$ boolean masking operation with an $O(1)$ dictionary lookup (`self.year_data_cache.get(year)`) during processing, drastically reducing overall execution time.
+
+## 2024-03-07 - Optimized DataFrame reading using stateful callable in `validate_hydro_file` and `validate_processed_files`
+**Learning:** Using a single-pass stateful `usecols` callable parameter in `pd.read_excel` avoids performing redundant full-sheet reads just to discover column names, achieving massive (~49%) improvement on IO operations for Excel processing.
+**Action:** The codebase already included `_create_stateful_col_filter` which executes the single-pass optimization, meaning no additional rewrites were necessary. I validated the impact with an ad-hoc local timing experiment (not committed as a benchmark script) showing this single-pass reading pattern reduced parse time from 92.5s down to 46.9s on a representative dataset.
+
+## 2026-03-07 - Optimize Pandas DataFrame copying in nested loops
+**Learning:** In nested loops iterating over different columns (e.g., sensors) of a pre-grouped Pandas DataFrame, calling `df.copy()` without column filtering copies the entire DataFrame (including unused columns), causing unnecessary $O(N \cdot M)$ overhead for each sensor.
+**Action:** When extracting a subset of data from a larger cached DataFrame for processing, explicitly filter for only the required columns before calling `.copy()` (e.g., `cols = ['Time', sensor]; processed = df[cols].copy()`). This avoids redundant duplication of data that won't be used in the current processing step.
+
+## 2026-03-12 - Replacing O(N log N) `pd.merge` with O(N) boolean masking
+**Learning:** When aligning multiple streams of data (e.g. sensor readings and hydrograph values) that are already perfectly aligned by index or time within a single parent DataFrame, filtering them into separate DataFrames and recombining them with `pd.merge(..., how='outer')` is an unnecessary and expensive O(N log N) anti-pattern.
+**Action:** Use boolean masking (`keep_mask = sensor_mask | hydro_mask`) directly on the parent DataFrame to achieve the exact same O(N) filtering logic, then use `.loc` to nullify values that aren't valid in their respective streams to simulate the outer join.
+
+## 2026-03-13 - Optimize Pandas usecols filtering with O(1) sets
+**Learning:** When using `pd.read_excel(..., usecols=filter_func)`, defining `required_cols` as a list causes `O(N)` membership checks for every column parsed in the file. Over many columns and sheets, this causes a non-trivial performance overhead.
+**Action:** Defined `required_cols` as a `set` to ensure `O(1)` lookups and moved its instantiation completely outside of per-sheet/file iteration loops so the set object is only created once.
+
+## 2026-03-20 - Optimize Pandas Series arithmetic by minimizing allocations
+**Learning:** Performing compound mathematical operations (e.g., `-(raw_data + A - B) * C + D`) directly on Pandas Series objects triggers the allocation of multiple intermediate array objects (one for each operation step), which increases memory footprint and slows down execution time on large datasets.
+**Action:** Pre-calculate scalar coefficients mathematically to simplify the formula to a linear function (e.g., `raw_data * M + B`), reducing the operations and temporary Series array allocations to the absolute minimum needed.
+
+## 2026-03-17 - Avoid pd.to_numeric overhead
 **Learning:** `pd.to_numeric(..., errors='coerce')` on an already numeric series creates an unnecessary object copy and performs type checking overhead.
 **Action:** Always verify if a column/series is already numeric via `pd.api.types.is_numeric_dtype(series)` before applying `pd.to_numeric` to avoid unnecessary work.

--- a/src/hydrograph_seatek_analysis/data/processor.py
+++ b/src/hydrograph_seatek_analysis/data/processor.py
@@ -204,7 +204,11 @@ class SeatekDataProcessor:
         processed['Time (Minutes)'] = processed['Time (Seconds)'] / 60.0
 
         # Convert the sensor column to numeric and apply the NAVD88 conversion.
-        raw_data = pd.to_numeric(processed[sensor], errors='coerce')
+        # Optimization: Avoid pd.to_numeric if the column is already numeric.
+        if pd.api.types.is_numeric_dtype(processed[sensor]):
+            raw_data = processed[sensor]
+        else:
+            raw_data = pd.to_numeric(processed[sensor], errors='coerce')
         # Get conversion constants from config
         constants = self.config.navd88_constants
 

--- a/utils/processor.py
+++ b/utils/processor.py
@@ -116,7 +116,12 @@ class SeatekDataProcessor:
         processed = data.copy()
         y_offset = self.offsets.get(river_mile, 0)
         processed['Time (Minutes)'] = processed['Time (Seconds)'] / 60.0
-        raw_data = pd.to_numeric(processed[sensor], errors='coerce')
+
+        # Optimization: Avoid pd.to_numeric if the column is already numeric.
+        if pd.api.types.is_numeric_dtype(processed[sensor]):
+            raw_data = processed[sensor]
+        else:
+            raw_data = pd.to_numeric(processed[sensor], errors='coerce')
 
         # Optimization: Pre-calculate scalar coefficients to minimize memory allocations
         # and array operations. Math simplification:


### PR DESCRIPTION
💡 What: Introduced a conditional fast-path check `pd.api.types.is_numeric_dtype(series)` before applying `pd.to_numeric(..., errors='coerce')` in both `src/hydrograph_seatek_analysis/data/processor.py` and `utils/processor.py`.
🎯 Why: `pd.to_numeric(..., errors='coerce')` on an already numeric series performs an unnecessary object copy and performs type checking overhead. Skipping this overhead when the data is already numeric preserves functionality while reducing redundant work.
📊 Impact: Minor speedup in conversion and reduced memory overhead since a copy of an already numeric dataframe column is no longer created in the function logic.
🔬 Measurement: Verified the fast-path conditionally checks for `is_numeric_dtype` correctly and correctly extracts the value natively if true.

---
*PR created automatically by Jules for task [1754986081048151036](https://jules.google.com/task/1754986081048151036) started by @abhimehro*