### PR TITLE
⚡ Bolt: [performance improvement] Calculate scalar columns upstream to avoid O(S*Y) redundant loop division

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2026-03-18 - Reuse Series and Cache Boolean Masks
 **Learning:** When performing multiple boolean checks (`isna().sum()`, `== 0.sum()`, `notna() & != 0`), extracting the series to a variable (`s = df[col]`) prevents duplicated DataFrame `__getitem__` overhead. Furthermore, you can apply De Morgan's Law `~(isna | iszero)` to calculate valid values by reusing the cached `isna()` and `== 0` masks from earlier metric collections.
 **Action:** Ensure intermediate mask calculations are saved to local variables (`sensor_isna = s.isna()`) and reused across both metric derivations and mask merging to skip redundant iterations over large arrays.
+
+## 2026-03-23 - Optimize Pandas array division by pre-calculating upstream
+**Learning:** Performing array operations (e.g., `processed['Time (Minutes)'] = processed['Time (Seconds)'] / 60.0`) repeatedly inside a nested loop over subsets of data redundantly executes the exact same mathematical operations multiple times per data file.
+**Action:** Shift scalar conversions and derived column creation upstream so they are computed exactly once during the initial data loading phase (e.g., right after `pd.read_excel`) to avoid `O(num_subsets)` redundant calculations on the hot path.

--- a/src/hydrograph_seatek_analysis/data/processor.py
+++ b/src/hydrograph_seatek_analysis/data/processor.py
@@ -96,6 +96,8 @@ class RiverMileData:
                 return col in required_cols or str(col).startswith('Sensor_') or col == 'Hydrograph (Lagged)'
 
             self.data = pd.read_excel(self.file_path, usecols=filter_cols)
+            if 'Time (Seconds)' in self.data.columns:
+                self.data['Time (Minutes)'] = self.data['Time (Seconds)'] / 60.0
             cols = list(seen_cols)
 
             # Check required columns
@@ -200,8 +202,6 @@ class SeatekDataProcessor:
         """
         processed = data.copy() if copy else data
         y_offset = self.offsets.get(river_mile, 0)
-        # Convert time from seconds to minutes.
-        processed['Time (Minutes)'] = processed['Time (Seconds)'] / 60.0
 
         # Convert the sensor column to numeric and apply the NAVD88 conversion.
         # Optimization: Avoid pd.to_numeric if the column is already numeric.
@@ -265,7 +265,7 @@ class SeatekDataProcessor:
         else:
             # Optimization: Only extract the required columns (Time, current sensor, and Hydrograph)
             # to avoid redundantly copying all other sensor columns on every iteration.
-            cols = ['Time (Seconds)', sensor]
+            cols = ['Time (Seconds)', 'Time (Minutes)', sensor]
             if 'Hydrograph (Lagged)' in cached_year_data.columns:
                 cols.append('Hydrograph (Lagged)')
             year_data = cached_year_data[cols].copy()

--- a/src/hydrograph_seatek_analysis/data/processor.py
+++ b/src/hydrograph_seatek_analysis/data/processor.py
@@ -96,8 +96,6 @@ class RiverMileData:
                 return col in required_cols or str(col).startswith('Sensor_') or col == 'Hydrograph (Lagged)'
 
             self.data = pd.read_excel(self.file_path, usecols=filter_cols)
-            if 'Time (Seconds)' in self.data.columns:
-                self.data['Time (Minutes)'] = self.data['Time (Seconds)'] / 60.0
             cols = list(seen_cols)
 
             # Check required columns
@@ -113,6 +111,8 @@ class RiverMileData:
             # Keep original validation steps to ensure no methods are bypassed
             self._validate_data()
             self._setup_sensors()
+
+            self.data['Time (Minutes)'] = self.data['Time (Seconds)'] / 60.0
 
             # Optimization: Pre-group data by year to avoid O(N) boolean masking
             # for each sensor during data processing.

--- a/src/hydrograph_seatek_analysis/data/processor.py
+++ b/src/hydrograph_seatek_analysis/data/processor.py
@@ -17,6 +17,8 @@ from ..core.config import Config
 
 logger = logging.getLogger(__name__)
 
+SECONDS_PER_MINUTE = 60.0
+
 
 @dataclass
 class ProcessingMetrics:
@@ -112,7 +114,7 @@ class RiverMileData:
             self._validate_data()
             self._setup_sensors()
 
-            self.data['Time (Minutes)'] = self.data['Time (Seconds)'] / 60.0
+            self.data['Time (Minutes)'] = self.data['Time (Seconds)'] / SECONDS_PER_MINUTE
 
             # Optimization: Pre-group data by year to avoid O(N) boolean masking
             # for each sensor during data processing.

--- a/test_perf.py
+++ b/test_perf.py
@@ -3,4 +3,5 @@ from unittest.mock import MagicMock
 sys.modules['pandas'] = MagicMock()
 sys.modules['numpy'] = MagicMock()
 import src.hydrograph_seatek_analysis.data.processor as p
-print(p)
+import utils.processor as up
+print("Imports successful!")

--- a/utils/processor.py
+++ b/utils/processor.py
@@ -59,6 +59,8 @@ class RiverMileData:
                 return col in required_cols or str(col).startswith('Sensor_') or col == 'Hydrograph (Lagged)'
 
             self.data = pd.read_excel(self.file_path, usecols=filter_cols)
+            if 'Time (Seconds)' in self.data.columns:
+                self.data['Time (Minutes)'] = self.data['Time (Seconds)'] / 60.0
 
             missing_cols = required_cols - set(seen_cols)
             if missing_cols:
@@ -115,7 +117,6 @@ class SeatekDataProcessor:
         """
         processed = data.copy()
         y_offset = self.offsets.get(river_mile, 0)
-        processed['Time (Minutes)'] = processed['Time (Seconds)'] / 60.0
 
         # Optimization: Avoid pd.to_numeric if the column is already numeric.
         if pd.api.types.is_numeric_dtype(processed[sensor]):
@@ -158,7 +159,7 @@ class SeatekDataProcessor:
         else:
             # Optimization: Only extract the required columns (Time, current sensor, and Hydrograph)
             # to avoid redundantly copying all other sensor columns on every iteration.
-            cols = ['Time (Seconds)', sensor]
+            cols = ['Time (Seconds)', 'Time (Minutes)', sensor]
             if 'Hydrograph (Lagged)' in cached_year_data.columns:
                 cols.append('Hydrograph (Lagged)')
             year_data = cached_year_data[cols]

--- a/utils/processor.py
+++ b/utils/processor.py
@@ -13,6 +13,8 @@ import pandas as pd
 import numpy as np
 logger = logging.getLogger(__name__)
 
+SECONDS_PER_MINUTE = 60.0
+
 @dataclass
 class ProcessingMetrics:
     """Metrics for data processing operations."""
@@ -67,7 +69,7 @@ class RiverMileData:
             self._validate_data()
             self._setup_sensors()
 
-            self.data['Time (Minutes)'] = self.data['Time (Seconds)'] / 60.0
+            self.data['Time (Minutes)'] = self.data['Time (Seconds)'] / SECONDS_PER_MINUTE
 
             # Optimization: Pre-group data by year to avoid O(N) boolean masking
             self.year_data_cache = {int(year): df for year, df in self.data.groupby('Year', sort=False)}

--- a/utils/processor.py
+++ b/utils/processor.py
@@ -59,8 +59,6 @@ class RiverMileData:
                 return col in required_cols or str(col).startswith('Sensor_') or col == 'Hydrograph (Lagged)'
 
             self.data = pd.read_excel(self.file_path, usecols=filter_cols)
-            if 'Time (Seconds)' in self.data.columns:
-                self.data['Time (Minutes)'] = self.data['Time (Seconds)'] / 60.0
 
             missing_cols = required_cols - set(seen_cols)
             if missing_cols:
@@ -68,6 +66,8 @@ class RiverMileData:
 
             self._validate_data()
             self._setup_sensors()
+
+            self.data['Time (Minutes)'] = self.data['Time (Seconds)'] / 60.0
 
             # Optimization: Pre-group data by year to avoid O(N) boolean masking
             self.year_data_cache = {int(year): df for year, df in self.data.groupby('Year', sort=False)}


### PR DESCRIPTION
💡 **What**: The optimization moves the calculation of the `Time (Minutes)` column (which is derived by dividing `Time (Seconds)` by `60.0`) upstream so that it is computed exactly once during the `load_data` phase immediately after the data is read from the Excel file via `pd.read_excel`. It then explicitly retains this column when slicing data for specific subsets, removing the need for a calculation on every subset.

🎯 **Why**: Previously, the `Time (Minutes)` conversion occurred inside `SeatekDataProcessor.convert_to_navd88()` or `process_data()`, which is executed inside a nested loop for *every* sensor for *every* year. Since `Time (Seconds)` does not change between sensors in the same file, the scalar division was redundantly executing the exact same mathematical array operation `O(num_sensors * num_years)` times per file.

📊 **Impact**: This drastically reduces `pandas.Series` object allocations and array math instructions by replacing potentially dozens of redundant divisions inside hot processing loops with a single operation per data file during load.

🔬 **Measurement**: Verify by inspecting that `processed['Time (Minutes)'] = processed['Time (Seconds)'] / 60.0` is completely absent from the nested processing iterations and exists solely upstream where the overarching `self.data` is materialized. Tests have been validated conceptually (via mock dependencies, as `pandas` is unavailable in the execution environment) and through syntax verification with `py_compile`.

---
*PR created automatically by Jules for task [12608672142155760275](https://jules.google.com/task/12608672142155760275) started by @abhimehro*