### PR TITLE
⚡ Bolt: [performance improvement] Pre-calculate Time (Minutes) to eliminate redundant array division

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2026-03-18 - Reuse Series and Cache Boolean Masks
 **Learning:** When performing multiple boolean checks (`isna().sum()`, `== 0.sum()`, `notna() & != 0`), extracting the series to a variable (`s = df[col]`) prevents duplicated DataFrame `__getitem__` overhead. Furthermore, you can apply De Morgan's Law `~(isna | iszero)` to calculate valid values by reusing the cached `isna()` and `== 0` masks from earlier metric collections.
 **Action:** Ensure intermediate mask calculations are saved to local variables (`sensor_isna = s.isna()`) and reused across both metric derivations and mask merging to skip redundant iterations over large arrays.
+
+## 2026-03-24 - Pre-calculate Time (Minutes) during data loading
+**Learning:** In the Seatek data processor, computing `Time (Minutes)` from `Time (Seconds)` inside `convert_to_navd88` forces a redundant calculation (`processed['Time (Minutes)'] = processed['Time (Seconds)'] / 60.0`) for every sensor and year combination. This redundantly executes an identical scalar array division inside deeply nested processing loops.
+**Action:** Move the `Time (Minutes)` calculation to the initial `load_data` phase before the `groupby('Year')` cache operation. This executes the array division precisely once per loaded Excel file, and downstream processes simply include `'Time (Minutes)'` when extracting required columns from the cached year data.

--- a/src/hydrograph_seatek_analysis/data/processor.py
+++ b/src/hydrograph_seatek_analysis/data/processor.py
@@ -112,6 +112,10 @@ class RiverMileData:
             self._validate_data()
             self._setup_sensors()
 
+            # ⚡ Bolt Optimization: Pre-calculate Time (Minutes) once during data loading
+            # to avoid redundantly dividing Time (Seconds) by 60 for every sensor and year combination
+            self.data['Time (Minutes)'] = self.data['Time (Seconds)'] / 60.0
+
             # Optimization: Pre-group data by year to avoid O(N) boolean masking
             # for each sensor during data processing.
             self.year_data_cache = {int(year): df for year, df in self.data.groupby('Year', sort=False)}
@@ -200,8 +204,12 @@ class SeatekDataProcessor:
         """
         processed = data.copy() if copy else data
         y_offset = self.offsets.get(river_mile, 0)
-        # Convert time from seconds to minutes.
-        processed['Time (Minutes)'] = processed['Time (Seconds)'] / 60.0
+
+        # ⚡ Bolt Optimization: Ensure Time (Minutes) is calculated if missing.
+        # This preserves backwards compatibility for external callers, while internal loops
+        # avoid redundant calculation by pre-calculating it during load_data.
+        if 'Time (Minutes)' not in processed.columns and 'Time (Seconds)' in processed.columns:
+            processed['Time (Minutes)'] = processed['Time (Seconds)'] / 60.0
 
         # Convert the sensor column to numeric and apply the NAVD88 conversion.
         # Optimization: Avoid pd.to_numeric if the column is already numeric.
@@ -265,7 +273,7 @@ class SeatekDataProcessor:
         else:
             # Optimization: Only extract the required columns (Time, current sensor, and Hydrograph)
             # to avoid redundantly copying all other sensor columns on every iteration.
-            cols = ['Time (Seconds)', sensor]
+            cols = ['Time (Seconds)', 'Time (Minutes)', sensor]
             if 'Hydrograph (Lagged)' in cached_year_data.columns:
                 cols.append('Hydrograph (Lagged)')
             year_data = cached_year_data[cols].copy()
@@ -274,7 +282,7 @@ class SeatekDataProcessor:
         if len(year_data) == 0:
             return pd.DataFrame(), metrics
 
-        # Convert the data and sensor values.
+        # Convert the sensor values.
         processed = self.convert_to_navd88(year_data, sensor, river_mile, copy=False)
 
         # ⚡ Bolt Optimization: Extract the underlying numpy arrays (.values) before applying

--- a/utils/processor.py
+++ b/utils/processor.py
@@ -171,7 +171,7 @@ class SeatekDataProcessor:
             year_data = cached_year_data[cols]
 
         metrics = ProcessingMetrics(original_rows=len(year_data))
-        if len(year_data) == 0:
+        if year_data.empty:
             return (pd.DataFrame(), metrics)
         processed = self.convert_to_navd88(year_data, sensor, river_mile)
 

--- a/utils/processor.py
+++ b/utils/processor.py
@@ -67,6 +67,10 @@ class RiverMileData:
             self._validate_data()
             self._setup_sensors()
 
+            # ⚡ Bolt Optimization: Pre-calculate Time (Minutes) once during data loading
+            # to avoid redundantly dividing Time (Seconds) by 60 for every sensor and year combination
+            self.data['Time (Minutes)'] = self.data['Time (Seconds)'] / 60.0
+
             # Optimization: Pre-group data by year to avoid O(N) boolean masking
             self.year_data_cache = {int(year): df for year, df in self.data.groupby('Year', sort=False)}
         except Exception as e:
@@ -115,7 +119,10 @@ class SeatekDataProcessor:
         """
         processed = data.copy()
         y_offset = self.offsets.get(river_mile, 0)
-        processed['Time (Minutes)'] = processed['Time (Seconds)'] / 60.0
+
+        # ⚡ Bolt Optimization: Ensure Time (Minutes) is calculated if missing.
+        if 'Time (Minutes)' not in processed.columns and 'Time (Seconds)' in processed.columns:
+            processed['Time (Minutes)'] = processed['Time (Seconds)'] / 60.0
 
         # Optimization: Avoid pd.to_numeric if the column is already numeric.
         if pd.api.types.is_numeric_dtype(processed[sensor]):
@@ -158,13 +165,13 @@ class SeatekDataProcessor:
         else:
             # Optimization: Only extract the required columns (Time, current sensor, and Hydrograph)
             # to avoid redundantly copying all other sensor columns on every iteration.
-            cols = ['Time (Seconds)', sensor]
+            cols = ['Time (Seconds)', 'Time (Minutes)', sensor]
             if 'Hydrograph (Lagged)' in cached_year_data.columns:
                 cols.append('Hydrograph (Lagged)')
             year_data = cached_year_data[cols]
 
         metrics = ProcessingMetrics(original_rows=len(year_data))
-        if year_data.empty:
+        if len(year_data) == 0:
             return (pd.DataFrame(), metrics)
         processed = self.convert_to_navd88(year_data, sensor, river_mile)
 


### PR DESCRIPTION
💡 What: Moved the `Time (Minutes)` calculation out of the deeply nested `convert_to_navd88` method and into the initial data loading phase in `load_data` before the `groupby` caching step.
🎯 Why: `convert_to_navd88` is called inside nested loops over every sensor and year. The original approach forced Pandas to redundantly perform the exact same scalar array division (`processed['Time (Seconds)'] / 60.0`) for every single combination. By calculating it once during the initial data load, we eliminate this redundant computation entirely.
📊 Impact: Reduces memory allocation and operation overhead by avoiding $O(Sensors \times Years)$ duplicate array divisions per river mile.
🔬 Measurement: Verify by executing the full suite using `python3 seatek_processor.py` (which internally leverages `app.py`) to confirm no processing logic was broken.

A critical learning entry was successfully appended to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [1360525176071320334](https://jules.google.com/task/1360525176071320334) started by @abhimehro*