### PR TITLE
🔒 [HIGH] Fix XXE Vulnerability with defusedxml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ scipy = "^1.12.0"
 openpyxl = "^3.1.2"
 colorlog = "^6.7.0"
 pyyaml = "^6.0.1"
+defusedxml = "^0.7.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         "numpy>=1.21.0",
         "colorlog>=6.7.0",
         "pyyaml>=6.0.0",
+        "defusedxml>=0.7.1",
     ],
     entry_points={
         "console_scripts": [

--- a/utils/security.py
+++ b/utils/security.py
@@ -4,7 +4,13 @@ import logging
 import re
 from pathlib import Path
 
+import defusedxml
+
 logger = logging.getLogger(__name__)
+
+# SECURITY: Patch standard library XML parsers to prevent XXE and entity expansion DoS attacks
+# This ensures that any downstream libraries (like openpyxl/pandas) are also protected.
+defusedxml.defuse_stdlib()
 
 
 def validate_file_size(file_path: Path, max_size_bytes: int) -> None:


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XXE Vulnerability with defusedxml

🎯 **What:** 
Added the `defusedxml` library as a dependency and initialized it globally in `utils/security.py` using `defusedxml.defuse_stdlib()`.

⚠️ **Risk:** 
`openpyxl` (used by `pandas` to read `.xlsx` files) parses XML files under the hood. Without `defusedxml`, it defaults to Python's standard library XML parsers, which are vulnerable to XML External Entity (XXE) attacks and XML Entity Expansion (Billion Laughs) DoS attacks. This could allow an attacker to read arbitrary files from the server, perform Server-Side Request Forgery (SSRF), or crash the application via memory exhaustion.

🛡️ **Solution:** 
- Added `defusedxml>=0.7.1` to `pyproject.toml` and `setup.py`.
- Added `defusedxml.defuse_stdlib()` to `utils/security.py` (which is imported globally) to monkey-patch and secure all standard library XML parsing against entity expansion vulnerabilities. `openpyxl` also automatically utilizes `defusedxml` if it's installed in the Python environment.
- Added corresponding documentation in the code.

✅ **Verification:** 
- Dependency configuration files are synchronized.
- Tests pass cleanly without regressions.

═════════ ELIR ═════════
PURPOSE: Mitigates XML-related vulnerabilities when parsing Excel files.
SECURITY: Protects against XXE and Billion Laughs DoS attacks by monkey-patching stdlib XML parsers using `defusedxml`.
FAILS IF: The application fails to install `defusedxml` or standard XML libraries break backwards compatibility.
VERIFY: Ensure that `defusedxml` is correctly installed in CI and `utils/security.py` is invoked early in execution paths.
MAINTAIN: Ensure `defusedxml` version is kept up-to-date and stays synchronized between `setup.py` and `pyproject.toml`.

---
*PR created automatically by Jules for task [3290577965780194130](https://jules.google.com/task/3290577965780194130) started by @abhimehro*