### PR TITLE
⚡ Bolt: Skip sort_values on already monotonic data

### DIFF
--- a/utils/processor.py
+++ b/utils/processor.py
@@ -291,7 +291,9 @@ class SeatekDataProcessor:
                 cols = ["Time (Seconds)", "Time (Minutes)", sensor]
 
             merged = merged[cols]
-            merged.sort_values("Time (Minutes)", inplace=True)
+            # ⚡ Bolt Optimization: Check if already sorted (O(N)) before doing O(N log N) sort
+            if not merged["Time (Minutes)"].is_monotonic_increasing:
+                merged.sort_values("Time (Minutes)", inplace=True)
         metrics.valid_rows = len(merged)
         metrics.invalid_rows = metrics.original_rows - len(processed)
         metrics.log_metrics()

--- a/utils/processor.py
+++ b/utils/processor.py
@@ -163,6 +163,26 @@ class SeatekDataProcessor:
         processed[sensor] = raw_data * m + b
         return processed
 
+    @staticmethod
+    def _get_merged_columns(
+        has_hydro: bool, sensor_any: bool, hydro_any: bool, sensor: str
+    ) -> List[str]:
+        """Determine the correct column order to match pd.merge output."""
+        if not has_hydro:
+            return ["Time (Seconds)", "Time (Minutes)", sensor]
+
+        if not sensor_any:
+            return ["Time (Seconds)", "Time (Minutes)", "Hydrograph (Lagged)"]
+        elif not hydro_any:
+            return ["Time (Seconds)", "Time (Minutes)", sensor]
+        else:
+            return [
+                "Time (Seconds)",
+                sensor,
+                "Time (Minutes)",
+                "Hydrograph (Lagged)",
+            ]
+
     def process_data(
         self, river_mile: float, year: int, sensor: str
     ) -> Tuple[pd.DataFrame, ProcessingMetrics]:
@@ -270,17 +290,12 @@ class SeatekDataProcessor:
                     merged["Hydrograph (Lagged)"] = 0
 
                 # Select and order columns identical to original pd.merge output
-                if not sensor_mask_arr.any():
-                    cols = ["Time (Seconds)", "Time (Minutes)", "Hydrograph (Lagged)"]
-                elif not hydro_mask_arr.any():
-                    cols = ["Time (Seconds)", "Time (Minutes)", sensor]
-                else:
-                    cols = [
-                        "Time (Seconds)",
-                        sensor,
-                        "Time (Minutes)",
-                        "Hydrograph (Lagged)",
-                    ]
+                cols = self._get_merged_columns(
+                    has_hydro=True,
+                    sensor_any=sensor_mask_arr.any(),
+                    hydro_any=hydro_mask_arr.any(),
+                    sensor=sensor
+                )
             else:
                 if not sensor_keep_arr.all():
                     merged.loc[~sensor_keep_arr, sensor] = (
@@ -288,7 +303,12 @@ class SeatekDataProcessor:
                         if pd.api.types.is_object_dtype(merged[sensor])
                         else np.nan
                     )
-                cols = ["Time (Seconds)", "Time (Minutes)", sensor]
+                cols = self._get_merged_columns(
+                    has_hydro=False,
+                    sensor_any=True, # Irrelevant when has_hydro is False
+                    hydro_any=False,
+                    sensor=sensor
+                )
 
             merged = merged[cols]
             # ⚡ Bolt Optimization: Check if already sorted (O(N)) before doing O(N log N) sort


### PR DESCRIPTION
⚡ Bolt: Skip sort_values on already monotonic data

💡 What: Conditionally check `is_monotonic_increasing` on 'Time (Minutes)' before executing `sort_values`.
🎯 Why: Time-series log streams are often already chronologically sorted. Pandas unconditional sort undergoes expensive $O(N \log N)$ operation to construct argsort arrays and reconstruct block managers.
📊 Impact: Avoids unnecessary $O(N \log N)$ overhead and block reconstruction when data is already sorted, by using highly optimized Cython-backed $O(N)$ property.
🔬 Measurement: Verify via micro-benchmark or performance profiler. Existing test suites confirm no logic changes.

---
*PR created automatically by Jules for task [11989669142657536075](https://jules.google.com/task/11989669142657536075) started by @abhimehro*