### PR TITLE
🧪 test: add exception path test for DataLoader._load_hydro_data

### DIFF
--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -142,6 +142,22 @@ def test_load_hydro_data_skips_invalid_sheet_value_error(
     assert list(result['RM_54.0'].columns) == list(expected_df.columns)
     assert "Skipping sheet RM_invalid: No columns to parse from file" in caplog.text
 
+@mock.patch('pandas.ExcelFile')
+def test_load_hydro_data_exception(mock_excel_file_cls, caplog):
+    """Test _load_hydro_data with an exception during ExcelFile initialization."""
+    mock_excel_file_cls.side_effect = RuntimeError("Test error")
+
+    config = Config()
+    data_loader = DataLoader(config)
+
+    with mock.patch.object(Path, 'exists', return_value=True):
+        with mock.patch.object(Path, 'stat') as mock_stat:
+            mock_stat.return_value.st_size = 1000
+            with pytest.raises(RuntimeError, match="Test error"):
+                data_loader._load_hydro_data()
+
+    assert "Error loading hydrograph data: Test error" in caplog.text
+
 @mock.patch.object(DataLoader, '_load_hydro_data')
 @mock.patch.object(DataLoader, '_load_summary_data')
 def test_load_all_data_success(mock_load_summary, mock_load_hydro):


### PR DESCRIPTION
### 🎯 What
Added a new unit test `test_load_hydro_data_exception` to address a missing exception path test in `DataLoader._load_hydro_data`.

### 📊 Coverage
The new test covers the following scenario:
- Simulates a failure during `pd.ExcelFile` initialization (e.g., file corruption or parsing error).
- Asserts that the `DataLoader` correctly logs the error message using the expected pattern.
- Asserts that the original exception is re-raised to the caller.

### ✨ Result
Increased the reliability of the `DataLoader` by ensuring its error handling and logging logic is formally verified. This prevents regressions in error reporting during data ingestion.

---
*PR created automatically by Jules for task [14151165608254372746](https://jules.google.com/task/14151165608254372746) started by @abhimehro*