### PR TITLE
test(data_loader): add exception-path test for _load_hydro_data (salvages #145)

### DIFF
--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -144,6 +144,31 @@ def test_load_hydro_data_skips_invalid_sheet_value_error(
     assert "Skipping sheet RM_invalid: No columns to parse from file" in caplog.text
 
 
+@mock.patch('pandas.ExcelFile')
+def test_load_hydro_data_exception(mock_excel_file_cls, caplog):
+    """Test _load_hydro_data with an exception during ExcelFile initialization.
+
+    Salvaged from PR #145. Asserts that _load_hydro_data correctly propagates
+    a RuntimeError from pandas.ExcelFile (e.g. corrupted workbook) rather than
+    silently swallowing it, and that a sanitized error line is logged.
+    """
+    mock_excel_file_cls.side_effect = RuntimeError("Test error")
+
+    config = Config()
+    data_loader = DataLoader(config)
+
+    with (
+        mock.patch.object(Path, 'is_symlink', return_value=False),
+        mock.patch.object(Path, 'exists', return_value=True),
+        mock.patch.object(Path, 'stat') as mock_stat,
+    ):
+        mock_stat.return_value.st_size = 1000
+        with pytest.raises(RuntimeError, match="Test error"):
+            data_loader._load_hydro_data()
+
+    assert "Error loading hydrograph data: Test error" in caplog.text
+
+
 @mock.patch.object(DataLoader, "_load_hydro_data")
 @mock.patch.object(DataLoader, "_load_summary_data")
 def test_load_all_data_success(mock_load_summary, mock_load_hydro):

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -157,14 +157,12 @@ def test_load_hydro_data_exception(mock_excel_file_cls, caplog):
     config = Config()
     data_loader = DataLoader(config)
 
-    with (
-        mock.patch.object(Path, 'is_symlink', return_value=False),
-        mock.patch.object(Path, 'exists', return_value=True),
-        mock.patch.object(Path, 'stat') as mock_stat,
-    ):
-        mock_stat.return_value.st_size = 1000
-        with pytest.raises(RuntimeError, match="Test error"):
-            data_loader._load_hydro_data()
+    with mock.patch.object(Path, "is_symlink", return_value=False):
+        with mock.patch.object(Path, "exists", return_value=True):
+            with mock.patch.object(Path, "stat") as mock_stat:
+                mock_stat.return_value.st_size = 1000
+                with pytest.raises(RuntimeError, match="Test error"):
+                    data_loader._load_hydro_data()
 
     assert "Error loading hydrograph data: Test error" in caplog.text
 

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -144,7 +144,7 @@ def test_load_hydro_data_skips_invalid_sheet_value_error(
     assert "Skipping sheet RM_invalid: No columns to parse from file" in caplog.text
 
 
-@mock.patch('pandas.ExcelFile')
+@mock.patch("pandas.ExcelFile")
 def test_load_hydro_data_exception(mock_excel_file_cls, caplog):
     """Test _load_hydro_data with an exception during ExcelFile initialization.
 


### PR DESCRIPTION
## Summary

Salvages the unique unit test from PR #145 (which became DIRTY in the post-Lesson-0-cascade `main`). Adds 1 test that asserts `DataLoader._load_hydro_data` correctly propagates a `RuntimeError` from `pandas.ExcelFile` (e.g. corrupted workbook) rather than silently swallowing it, and that a sanitized error line is logged.

## Why salvage rather than rebase #145

PR #145's branch was DIRTY with conflicts in `tests/test_data_loader.py` after several test-file additions on `main`. This PR re-applies just the new test on top of current `main`, with one adaptation:

`validate_file_size` is now called inside `_load_hydro_data` before `pd.ExcelFile`, and it calls `is_symlink`, `exists`, and `stat` on the `Path`. Updated the mock to patch all three so the test exercises the actual `pd.ExcelFile` exception path instead of failing earlier in `validate_file_size`.

## Verification

```
$ python3 -m pytest tests/test_data_loader.py -v
... 10 passed in 0.21s
```

═══ ELIR ═══
PURPOSE: Lock in the `_load_hydro_data` exception-propagation contract so a future refactor cannot accidentally swallow a corrupted-workbook error.
SECURITY: Pure test addition. No new permissions, no new external deps. Tests file IO only via mocks.
FAILS IF: `_load_hydro_data` is renamed (test catches it). `validate_file_size`'s API changes again — the mock list (`is_symlink` / `exists` / `stat`) would need to be extended.
VERIFY: Run `pytest tests/test_data_loader.py` — should be 10 passes including `test_load_hydro_data_exception`.
MAINTAIN: If a 3rd file path becomes part of `_load_hydro_data` (e.g. a separate metadata file), add a corresponding mock for that Path's stat call.