### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Path Traversal in utils/utils.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -52,3 +52,9 @@
 **Vulnerability:** Path traversal and path-length Denial of Service (DoS) vulnerability in legacy visualization tools (`tests/data_processing/__init__.py`) where untrusted string variables (`year`, `river_mile`, and `sensor` from parsed Excel data) were passed directly to `os.path.join` and `f-strings` to generate output directories and filenames.
 **Learning:** Even scripts outside of the primary production path (`src/`) often generate artifacts. If these scripts process external data files and construct file paths dynamically based on the contents, they are vulnerable to arbitrary file write or DoS if sanitization is omitted.
 **Prevention:** Always implement `sanitize_filename` from `utils.security` on dynamic components (e.g., `river_mile`, `sensor`, `year`) before using them in file path constructions, including inside test or utility scripts.
+
+## 2026-04-05 - Path Traversal Vulnerability in utils/utils.py
+
+**Vulnerability:** Path traversal and path-length Denial of Service (DoS) vulnerability in legacy visualization tools (`utils/utils.py`) where an untrusted variable (`rm` from data) was passed directly to an `f-string` and concatenated to a `pathlib.Path` to generate output directories.
+**Learning:** Even scripts outside of the primary production path (`src/`) often generate artifacts. If these scripts process external data files and construct file paths dynamically based on the contents, they are vulnerable to arbitrary file write or DoS if sanitization is omitted.
+**Prevention:** Always implement `sanitize_filename` from `utils.security` on dynamic components (e.g., `rm`, `river_mile`, `sensor`, `year`) before using them in file path constructions, including inside test or utility scripts.

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -5,7 +5,7 @@ from typing import List
 
 from pandas import DataFrame, ExcelFile, Series, read_excel
 
-from utils.security import validate_file_size
+from utils.security import validate_file_size, sanitize_filename
 
 
 class DataVisualizationError(Exception):
@@ -71,7 +71,8 @@ def load_excel_file(file_path: Path) -> DataFrame:
 def create_output_dir(rm: float) -> Path:
     """Create the output directory for a specific river mile."""
     project_root = get_project_root()
-    output_dir = project_root / "output" / f"RM_{rm}"
+    safe_rm = sanitize_filename(str(rm))
+    output_dir = project_root / "output" / f"RM_{safe_rm}"
     output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir
 


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: Path traversal vulnerability in `create_output_dir` where untrusted input `rm` is concatenated directly into a file path without sanitization. Although typed as `float`, runtime duck-typing allows malicious string payloads from unvalidated external data.
* 🎯 Impact: This could allow an attacker to write files or traverse directories in arbitrary locations on the filesystem.
* 🔧 Fix: Added `sanitize_filename` from `utils.security` to sanitize the `rm` input (cast to string) before path creation in `utils/utils.py`.
* ✅ Verification: Verified by running the existing test suite which passed successfully, and static analysis/code review.

---
*PR created automatically by Jules for task [18332920613588863696](https://jules.google.com/task/18332920613588863696) started by @abhimehro*