### PR TITLE
⚡ Bolt: Remove dropna() overhead before min, max, and unique

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -93,3 +93,7 @@
 ## 2024-05-25 - Replace df[cols].isna().sum() with dictionary comprehension and np.count_nonzero
 **Learning:** Using `df[cols].isna().sum()` inside loops creates an intermediate boolean dataframe mask in memory, and then aggregates it over the columns, leading to implicit upcasting of booleans to integers and significant memory allocation overhead. Replacing it with `pd.Series({col: np.count_nonzero(pd.isna(df[col].values)) for col in cols})` bypasses intermediate Pandas DataFrame overhead and utilizes optimized Cython/numpy routines, making the operation significantly faster.
 **Action:** Replaced `df[cols].isna().sum()` with `pd.Series({col: np.count_nonzero(pd.isna(df[col].values)) for col in cols})` to avoid intermediate object creation and utilize optimized cython numpy routines. Ensure `numpy` is imported.
+
+## 2024-05-25 - Avoid dropna() before min(), max(), and unique() for Pandas Series
+**Learning:** Calling `dropna()` before `min()` or `max()` creates an unnecessary intermediate Series object in memory, as Pandas native `.min()` and `.max()` methods already ignore NaNs by default. Similarly, `dropna().unique()` creates a full Series copy just to find unique values.
+**Action:** Remove `dropna()` before `min()` and `max()`. For `unique()`, extract unique values first and filter out NaNs (e.g., using `[int(y) for y in s.unique() if not pd.isna(y)]`).

--- a/src/hydrograph_seatek_analysis/data/validator.py
+++ b/src/hydrograph_seatek_analysis/data/validator.py
@@ -119,7 +119,8 @@ class DataValidator:
             return None
         if not df["Year"].notna().any():
             return None
-        return sorted([int(y) for y in df["Year"].unique() if not pd.isna(y)])
+        years = df["Year"].unique()
+        return sorted(years[pd.notna(years)].astype(int).tolist())
 
     def _extract_hydro_time_range(self, df: pd.DataFrame) -> Optional[List[float]]:
         """Helper to extract time range safely."""

--- a/src/hydrograph_seatek_analysis/data/validator.py
+++ b/src/hydrograph_seatek_analysis/data/validator.py
@@ -119,7 +119,7 @@ class DataValidator:
             return None
         if not df["Year"].notna().any():
             return None
-        return sorted(df["Year"].dropna().unique().astype(int).tolist())
+        return sorted([int(y) for y in df["Year"].unique() if not pd.isna(y)])
 
     def _extract_hydro_time_range(self, df: pd.DataFrame) -> Optional[List[float]]:
         """Helper to extract time range safely."""
@@ -128,8 +128,8 @@ class DataValidator:
         if not df["Time (Seconds)"].notna().any():
             return None
         return [
-            df["Time (Seconds)"].dropna().min(),
-            df["Time (Seconds)"].dropna().max(),
+            df["Time (Seconds)"].min(),
+            df["Time (Seconds)"].max(),
         ]
 
     def _process_hydro_sheet(self, excel, hydro_file, sheet: str) -> Dict[str, Any]:

--- a/test_perf.py
+++ b/test_perf.py
@@ -1,8 +1,6 @@
-import sys
-from unittest.mock import MagicMock
-
-sys.modules["pandas"] = MagicMock()
-sys.modules["numpy"] = MagicMock()
-import src.hydrograph_seatek_analysis.data.processor as p
-
-print(p)
+import pandas as pd
+import numpy as np
+df = pd.DataFrame({'Year': [2020.0, 2021.0, np.nan, 2020.0]})
+years = df["Year"].unique()
+valid_years = years[pd.notna(years)]
+print(sorted(valid_years.astype(int).tolist()))


### PR DESCRIPTION
💡 What: Replaced `dropna().min()` and `dropna().max()` with `.min()` and `.max()` and rewrote `dropna().unique()` to a list comprehension that checks for NaNs.
🎯 Why: Calling `dropna()` before these aggregation functions creates unnecessary intermediate Series objects in memory. Pandas `.min()` and `.max()` natively ignore NaNs by default, allowing us to drop the `.dropna()` call entirely. Similarly, using a list comprehension after `.unique()` is faster than creating an intermediate filtered Series.
📊 Impact: Avoids unnecessary O(N) array copies in memory and improves the performance of value range extractions.
🔬 Measurement: Validated test coverage with pytest to ensure extracted values correctly ignore NaNs.

---
*PR created automatically by Jules for task [3270605699398510761](https://jules.google.com/task/3270605699398510761) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/hydrograph_versus_seatek_sensors_project/pull/163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->