### PR TITLE
fix(lint): remove extra blank lines in validator.py (E303)

### DIFF
--- a/src/hydrograph_seatek_analysis/data/validator.py
+++ b/src/hydrograph_seatek_analysis/data/validator.py
@@ -40,7 +40,6 @@ class DataValidator:
 
         return filter_func, seen_cols
 
-
     def _calculate_missing_values(self, df: pd.DataFrame, columns: set) -> pd.Series:
         """Helper to calculate missing values efficiently."""
         # ⚡ Bolt Optimization: Replace df[cols].isna().sum() with dictionary comprehension and np.count_nonzero
@@ -110,8 +109,6 @@ class DataValidator:
         except Exception as e:
             logger.error(f"Error validating summary file: {str(e)}")
             return None
-
-
 
     def _extract_hydro_years(self, df: pd.DataFrame) -> Optional[List[int]]:
         """Helper to extract years safely."""
@@ -203,8 +200,6 @@ class DataValidator:
         except Exception as e:
             logger.error(f"Error validating hydrograph file: {str(e)}")
             return None
-
-
 
     def _extract_processed_year_range(self, df: pd.DataFrame) -> Optional[List[int]]:
         if "Year" not in df.columns or len(df) == 0:


### PR DESCRIPTION
## Description

- **Motivation**: Remove extraneous blank lines between class methods in `src/hydrograph_seatek_analysis/data/validator.py` that violated flake8 E303 (too many blank lines). Methods within a class body should be separated by a single blank line per PEP 8.
- **Fixes Issue**: Flake8 E303 violations in `validator.py`

---

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Testing Instructions

**Tests Performed**:

- [x] Test A: `MPLBACKEND=Agg python3 -m pytest tests/test_config.py tests/test_logger.py tests/test_validator.py tests/test_data_loader.py tests/test_data_processor.py` — 33 passed
- [x] Test B: `flake8 src/` — no E303 violations remaining (only pre-existing E501 line-length)

---

## Checklist

- [x] Code adheres to project style guidelines.
- [x] A self-review has been performed.
- [x] No new warnings have been introduced.
- [x] Tests prove the feature or fix works as intended.
- [x] Unit tests pass locally.

Link to Devin session: https://app.devin.ai/sessions/bf72bdef1e9243f28091d81269dcd68d
Requested by: @abhimehro