### PR TITLE
🧪 [testing improvement] Add edge case tests for get_available_river_miles

### DIFF
--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,9 @@
+🧪 [testing improvement] Add edge case tests for get_available_river_miles
+
+🎯 What: Added tests for the `get_available_river_miles` method in `DataLoader` to cover missing edge cases, such as handling a missing processed directory and ignoring files with invalid formats (e.g., `RM_invalid.xlsx`, `RM_.xlsx`).
+
+📊 Coverage:
+- Added `test_get_available_river_miles_dir_not_found` to ensure a `FileNotFoundError` is raised when the provided directory does not exist.
+- Added `test_get_available_river_miles_invalid_format` to verify that files with invalid names are safely ignored, a warning is logged, and valid files are still successfully processed.
+
+✨ Result: Improved test coverage and reliability for river mile data loading by ensuring robust handling of unexpected file system states and invalid file formats.

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -204,3 +204,29 @@ def test_load_all_data_exception(mock_load_summary, mock_load_hydro):
 
     mock_load_summary.assert_called_once()
     mock_load_hydro.assert_not_called()
+
+def test_get_available_river_miles_dir_not_found():
+    """Test get_available_river_miles raises FileNotFoundError if dir doesn't exist."""
+    with pytest.raises(FileNotFoundError, match="Processed data directory not found"):
+        DataLoader.get_available_river_miles(Path("/nonexistent/path/that/should/not/exist"))
+
+
+def test_get_available_river_miles_invalid_format(caplog):
+    """Test get_available_river_miles with invalid river mile file formats."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Valid file
+        (temp_path / "RM_54.0.xlsx").touch()
+        # Invalid value for float conversion
+        (temp_path / "RM_invalid.xlsx").touch()
+        # Edge case: empty string after RM_
+        (temp_path / "RM_.xlsx").touch()
+
+        result = DataLoader.get_available_river_miles(temp_path)
+
+        # Only the valid file should be parsed
+        assert result == [54.0]
+        # Check that warnings were logged
+        assert "Skipping invalid river mile file: RM_invalid.xlsx" in caplog.text
+        assert "Skipping invalid river mile file: RM_.xlsx" in caplog.text


### PR DESCRIPTION
🎯 **What:** Added tests for the `get_available_river_miles` method in `DataLoader` to cover missing edge cases, such as handling a missing processed directory and ignoring files with invalid formats (e.g., `RM_invalid.xlsx`, `RM_.xlsx`).

📊 **Coverage:**
- Added `test_get_available_river_miles_dir_not_found` to ensure a `FileNotFoundError` is raised when the provided directory does not exist.
- Added `test_get_available_river_miles_invalid_format` to verify that files with invalid names are safely ignored, a warning is logged, and valid files are still successfully processed.

✨ **Result:** Improved test coverage and reliability for river mile data loading by ensuring robust handling of unexpected file system states and invalid file formats.

---
*PR created automatically by Jules for task [11826211789483572578](https://jules.google.com/task/11826211789483572578) started by @abhimehro*