### PR TITLE
perf(data): Bolt optimizations v2 (salvages #223, #224; supersedes #227)

### DIFF
--- a/src/hydrograph_seatek_analysis/data/data_loader.py
+++ b/src/hydrograph_seatek_analysis/data/data_loader.py
@@ -68,15 +68,9 @@ class DataLoader:
 
             # Optimize: load columns dynamically to avoid checking headers and reloading
             # This is an optimization for reading excel files in a single pass
-            seen_cols = []
+            df = pd.read_excel(summary_file, usecols=lambda col: col in required_cols)
 
-            def filter_cols(col):
-                seen_cols.append(col)
-                return col in required_cols
-
-            df = pd.read_excel(summary_file, usecols=filter_cols)
-
-            missing_cols = [col for col in required_cols if col not in seen_cols]
+            missing_cols = [col for col in required_cols if col not in df.columns]
             if missing_cols:
                 raise ValueError(
                     f"Missing required columns in summary data: {missing_cols}"
@@ -120,16 +114,6 @@ class DataLoader:
                     continue
 
                 # Optimize: Load only required columns and sensor/hydrograph columns to reduce memory usage and speed up loading
-                seen_cols = []
-
-                def filter_cols(col):
-                    seen_cols.append(col)
-                    return (
-                        col in required_cols
-                        or str(col).startswith("Sensor_")
-                        or col == "Hydrograph (Lagged)"
-                    )
-
                 try:
                     # SECURITY: Limit file size to prevent memory exhaustion (DoS)
                     validate_file_size(hydro_file, self.config.max_file_size_bytes)
@@ -137,13 +121,17 @@ class DataLoader:
                     df = pd.read_excel(
                         excel_file,
                         sheet_name=sheet_name,
-                        usecols=filter_cols,
+                        usecols=lambda col: (
+                            col in required_cols
+                            or str(col).startswith("Sensor_")
+                            or col == "Hydrograph (Lagged)"
+                        ),
                     )
                 except ValueError as exc:
                     logger.warning(f"Skipping sheet {sheet_name}: {exc}")
                     continue
 
-                missing_cols = [col for col in required_cols if col not in seen_cols]
+                missing_cols = [col for col in required_cols if col not in df.columns]
                 if missing_cols:
                     logger.warning(
                         f"Skipping sheet {sheet_name}: Missing required columns in sheet {sheet_name}: {missing_cols}"

--- a/src/hydrograph_seatek_analysis/data/processor.py
+++ b/src/hydrograph_seatek_analysis/data/processor.py
@@ -8,7 +8,7 @@ and merges the two streams using a full outer join so that all valid sensor read
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -185,7 +185,9 @@ class SeatekDataProcessor:
 
     def _setup_offsets(self) -> None:
         """Setup Y_Offset values for each river mile from the summary data."""
-        self.offsets = dict(zip(self.summary_data["River_Mile"], self.summary_data["Y_Offset"]))
+        self.offsets = dict(
+            zip(self.summary_data["River_Mile"], self.summary_data["Y_Offset"])
+        )
 
     def convert_to_navd88(
         self, data: pd.DataFrame, sensor: str, river_mile: float, copy: bool = True
@@ -239,6 +241,34 @@ class SeatekDataProcessor:
         processed[sensor] = raw_data * m + b
 
         return processed
+
+    def _get_na_value(self, series: pd.Series) -> Any:
+        """Return the appropriate NA sentinel for the series dtype.
+
+        Args:
+            series: The pandas Series to check.
+
+        Returns:
+            ``pd.NA`` for object-dtype series, ``np.nan`` otherwise.
+        """
+        return pd.NA if pd.api.types.is_object_dtype(series) else np.nan
+
+    def _create_empty_merged(
+        self, has_hydro: bool, sensor_any: bool, hydro_any: bool, sensor: str
+    ) -> pd.DataFrame:
+        """Create an empty DataFrame with the correct merged column order.
+
+        Args:
+            has_hydro: Whether hydrograph data is present.
+            sensor_any: Whether any valid sensor readings exist.
+            hydro_any: Whether any valid hydrograph readings exist.
+            sensor: Name of the sensor column.
+
+        Returns:
+            An empty DataFrame with the appropriate columns.
+        """
+        cols = self._get_merged_columns(has_hydro, sensor_any, hydro_any, sensor)
+        return pd.DataFrame(columns=cols)
 
     def _get_merged_columns(
         self, has_hydro: bool, sensor_any: bool, hydro_any: bool, sensor: str
@@ -331,61 +361,50 @@ class SeatekDataProcessor:
         # pd.Series wrapper allocations entirely for boolean logic combinations.
         sensor_mask_arr = ~(sensor_isna | sensor_iszero)
 
+        sensor_any = sensor_mask_arr.any()
+
+        hydro_any = False
+        keep_mask_arr = sensor_mask_arr
+
         if has_hydro:
             hydro_vals = processed["Hydrograph (Lagged)"].values
             hydro_mask_arr = ~pd.isna(hydro_vals) & (hydro_vals != 0)
+            hydro_any = hydro_mask_arr.any()
             keep_mask_arr = sensor_mask_arr | hydro_mask_arr
-        else:
-            hydro_mask_arr = np.zeros(len(processed), dtype=bool)
-            keep_mask_arr = sensor_mask_arr
 
-        # If no valid readings exist for both streams, return appropriate early empty df.
-        if not keep_mask_arr.any():
-            hydro_any = hydro_mask_arr.any() if has_hydro else False
-            cols = self._get_merged_columns(
-                has_hydro, sensor_mask_arr.any(), hydro_any, sensor
+        keep_any = sensor_any or hydro_any
+
+        if not keep_any:
+            merged = self._create_empty_merged(has_hydro, sensor_any, hydro_any, sensor)
+            metrics.valid_rows = 0
+            metrics.invalid_rows = metrics.original_rows - len(processed)
+            metrics.log_metrics()
+            return merged, metrics
+
+        merged = processed[keep_mask_arr].copy()
+        sensor_keep_arr = sensor_mask_arr[keep_mask_arr]
+
+        if not sensor_keep_arr.all():
+            merged.loc[~sensor_keep_arr, sensor] = (
+                self._get_na_value(merged[sensor]) if has_hydro else np.nan
             )
-            merged = pd.DataFrame(columns=cols)
-        else:
-            # Filter processed data using the union mask
-            merged = processed[keep_mask_arr].copy()
 
-            # Sub-masks on the filtered data
-            sensor_keep_arr = sensor_mask_arr[keep_mask_arr]
+        if has_hydro:
             hydro_keep_arr = hydro_mask_arr[keep_mask_arr]
+            if not hydro_keep_arr.all():
+                merged.loc[~hydro_keep_arr, "Hydrograph (Lagged)"] = self._get_na_value(
+                    merged["Hydrograph (Lagged)"]
+                )
 
-            # Nullify values that are not valid in their respective streams
-            if has_hydro:
-                if not sensor_keep_arr.all():
-                    merged.loc[~sensor_keep_arr, sensor] = (
-                        pd.NA
-                        if pd.api.types.is_object_dtype(merged[sensor])
-                        else np.nan
-                    )
-                if not hydro_keep_arr.all():
-                    merged.loc[~hydro_keep_arr, "Hydrograph (Lagged)"] = (
-                        pd.NA
-                        if pd.api.types.is_object_dtype(merged["Hydrograph (Lagged)"])
-                        else np.nan
-                    )
+            if not sensor_any and hydro_any:
+                merged["Hydrograph (Lagged)"] = 0
 
-                # If no valid sensor readings exist but hydrograph data exist, force hydrograph to 0
-                if not sensor_mask_arr.any() and hydro_mask_arr.any():
-                    merged["Hydrograph (Lagged)"] = 0
+        cols = self._get_merged_columns(has_hydro, sensor_any, hydro_any, sensor)
+        merged = merged[cols]
 
-            else:
-                if not sensor_keep_arr.all():
-                    merged.loc[~sensor_keep_arr, sensor] = np.nan
-
-            hydro_any = hydro_mask_arr.any() if has_hydro else False
-            cols = self._get_merged_columns(
-                has_hydro, sensor_mask_arr.any(), hydro_any, sensor
-            )
-            merged = merged[cols]
-
-            # Optimization: Check if already sorted (O(N)) before doing O(N log N) sort
-            if not merged["Time (Minutes)"].is_monotonic_increasing:
-                merged.sort_values("Time (Minutes)", inplace=True)
+        # Optimization: Check if already sorted (O(N)) before doing O(N log N) sort
+        if not merged["Time (Minutes)"].is_monotonic_increasing:
+            merged.sort_values("Time (Minutes)", inplace=True)
 
         metrics.valid_rows = len(merged)
         metrics.invalid_rows = metrics.original_rows - len(processed)


### PR DESCRIPTION
## Salvage (Phase 2) — v2 rebuild

Supersedes conflicted salvage **#227** (went `DIRTY` after `main` evolved) and original Jules/Bolt PRs **#223**, **#224**.

### Changes (intent files only — Lesson 0cd)
- `data_loader.py`: stateless `usecols=lambda` filter (#223)
- `processor.py`: `_get_na_value` / `_create_empty_merged` helpers + mask refactor (#224)

**Omitted:** `app.py` (main already has `_create_chart_metadata` / `_save_generated_chart` refactor), `.github/workflows/refactoring-agent.yml` (workflow churn).

### Verify
```bash
python3 -m pytest tests/test_data_loader.py tests/test_data_processor.py tests/test_validator.py -q
```

**Disposition:** Human review and merge. Closes #227 after this draft is opened.

═══ ELIR ═══
PURPOSE: Recover Bolt perf intent on current main without conflict regressions.
SECURITY: Data processing only; no auth/secrets surface.
FAILS IF: pytest subset fails or merge conflicts reappear on sync.
VERIFY: CI green except possible CodeScene advisory (Lesson 0ce contrast).
MAINTAIN: Rebuild from `main` after merge bursts — never `update-branch` on stale salvage (Lesson 0cc).