### PR TITLE
test(app): add main execution path coverage (salvages #245)

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,7 +5,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from src.hydrograph_seatek_analysis.app import Application
+from src.hydrograph_seatek_analysis.app import Application, main
 from src.hydrograph_seatek_analysis.core.config import Config
 
 
@@ -55,6 +55,53 @@ class TestApplication(unittest.TestCase):
 
         # Test loading data failure
         self.assertFalse(app.load_data())
+
+
+
+class TestMain(unittest.TestCase):
+    """Tests for the main function."""
+
+    @mock.patch("src.hydrograph_seatek_analysis.app.configure_root_logger")
+    @mock.patch("src.hydrograph_seatek_analysis.app.Application")
+    @mock.patch("src.hydrograph_seatek_analysis.app.Path")
+    def test_main_success(self, mock_path, mock_app_class, mock_configure_logger) -> None:
+        """Test main execution returning 0 on success."""
+        mock_app_instance = mock.MagicMock()
+        mock_app_instance.run.return_value = True
+        mock_app_class.return_value = mock_app_instance
+
+        exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        mock_app_instance.run.assert_called_once()
+        mock_configure_logger.assert_called_once()
+        mock_path.return_value.mkdir.assert_called_once_with(exist_ok=True)
+
+    @mock.patch("src.hydrograph_seatek_analysis.app.configure_root_logger")
+    @mock.patch("src.hydrograph_seatek_analysis.app.Application")
+    @mock.patch("src.hydrograph_seatek_analysis.app.Path")
+    def test_main_failure(self, mock_path, mock_app_class, mock_configure_logger) -> None:
+        """Test main execution returning 1 on app failure."""
+        mock_app_instance = mock.MagicMock()
+        mock_app_instance.run.return_value = False
+        mock_app_class.return_value = mock_app_instance
+
+        exit_code = main()
+
+        self.assertEqual(exit_code, 1)
+        mock_app_instance.run.assert_called_once()
+
+    @mock.patch("src.hydrograph_seatek_analysis.app.configure_root_logger")
+    @mock.patch("src.hydrograph_seatek_analysis.app.Path")
+    def test_main_exception(self, mock_path, mock_configure_logger) -> None:
+        """Test main execution returning 1 on exception."""
+        mock_configure_logger.side_effect = Exception("Test Exception")
+
+        with mock.patch("src.hydrograph_seatek_analysis.app.logging.error") as mock_logging_error:
+            exit_code = main()
+
+        self.assertEqual(exit_code, 1)
+        mock_logging_error.assert_called_once_with("Fatal error in main execution: Test Exception")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Salvage PR (Phase 2)

**Supersedes:** #245 (CONFLICTING/DIRTY)

### Purpose
Rebuilds test coverage from #245 onto fresh `main` (intent-file-only: `tests/test_app.py` only).

### Verification
```bash
MPLBACKEND=Agg python3 -m pytest tests/test_app.py -q
```

### ELIR
- **Purpose:** Adds main-function execution path tests salvaged from conflicted #245.
- **Security:** Test-only; no auth or subprocess changes.
- **Fails if:** `app.py` main entrypoint refactored without updating mocks.
- **Verify:** 6 tests pass locally with Agg backend.
- **Maintain:** Omit `app.py` from salvage when main has diverged (Lesson 0cd).