### PR TITLE
🧪 Add error path tests for SeatekDataProcessor.process_data

### DIFF
--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -125,3 +125,28 @@ def test_setup_sensors_error():
 
         with pytest.raises(ValueError, match="No sensor columns found"):
             river_mile_data._setup_sensors()
+
+def test_process_data_missing_river_mile():
+    """Test that process_data raises ValueError for an unknown river mile."""
+    config = Config()
+    summary_data = pd.DataFrame({"River_Mile": [54.0], "Y_Offset": [10.5], "Num_Sensors": [2]})
+    processor = SeatekDataProcessor(data_dir=config.processed_dir, summary_data=summary_data, config=config)
+
+    with pytest.raises(ValueError, match="No data loaded for River Mile 99.0"):
+        processor.process_data(99.0, 2023, "Sensor_1")
+
+def test_process_data_internal_error():
+    """Test that internal errors during processing propagate properly."""
+    config = Config()
+    summary_data = pd.DataFrame({"River_Mile": [54.0], "Y_Offset": [10.5], "Num_Sensors": [2]})
+    processor = SeatekDataProcessor(data_dir=config.processed_dir, summary_data=summary_data, config=config)
+
+    rm_data = mock.Mock()
+    rm_data.year_data_cache = {
+        2023: pd.DataFrame({"Time (Seconds)": [0], "Time (Minutes)": [0], "Sensor_1": [1.0]})
+    }
+    processor.river_mile_data[54.0] = rm_data
+
+    with mock.patch.object(processor, 'convert_to_navd88', side_effect=RuntimeError("Dataframe processing failed")):
+        with pytest.raises(RuntimeError, match="Dataframe processing failed"):
+            processor.process_data(54.0, 2023, "Sensor_1")


### PR DESCRIPTION
🎯 **What**: The testing gap addressed is the lack of error path coverage for `SeatekDataProcessor.process_data`. Added explicit tests to verify that it correctly raises a `ValueError` for an unknown river mile, and that internal errors during processing propagate properly.

📊 **Coverage**: The new scenarios tested include missing river miles and simulated internal execution failures (e.g., exceptions raised inside dataframe processing routines).

✨ **Result**: Increased the reliability and coverage of the data processing tests by explicitly verifying the failure modes of `process_data`.

---
*PR created automatically by Jules for task [11287135121931889765](https://jules.google.com/task/11287135121931889765) started by @abhimehro*