### PR TITLE
chore: fix minor flake8 warnings in test files

### DIFF
--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -12,6 +12,7 @@ Modules:
 """
 
 import logging
+import pandas as pd
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 

--- a/tests/visualization/test_chart_generator.py
+++ b/tests/visualization/test_chart_generator.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
 from matplotlib.figure import Figure
-import matplotlib.pyplot as plt
+
 from src.hydrograph_seatek_analysis.visualization.chart_generator import ChartGenerator, ChartMetrics
 from src.hydrograph_seatek_analysis.core.config import Config
 


### PR DESCRIPTION
This PR fixes minor flake8 warnings found during the daily automated QA review. Specifically, it resolves an undefined name error (`pd`) in `tests/utils/__init__.py` by adding the missing pandas import, and removes an unused import (`matplotlib.pyplot as plt`) in `tests/visualization/test_chart_generator.py`.

---
*PR created automatically by Jules for task [10314744291259017586](https://jules.google.com/task/10314744291259017586) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/hydrograph_versus_seatek_sensors_project/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->